### PR TITLE
Version parsed like Spacewalk server

### DIFF
--- a/client/debian/packages-already-in-debian/rhn-client-tools/src/up2date_client/debUtils.py
+++ b/client/debian/packages-already-in-debian/rhn-client-tools/src/up2date_client/debUtils.py
@@ -25,13 +25,14 @@ def verifyPackages(packages):
 
 def parseVRE(version):
     epoch = ''
-    release = '0'
-    if version.find(':') != -1:
-        epoch, version = version.split(':')
-    if version.find('-') != -1:
-        tmp = version.split('-')
-        version = '-'.join(tmp[:-1])
-        release = tmp[-1]
+    version_tmpArr = version.split('-')
+    if len(version_tmpArr) == 1:
+        version = version
+	release = 'X'
+    else:
+        version = version_tmpArr[0]
+        release = version_tmpArr[1]
+
     return version, release, epoch
 
 def installTime(pkg_name, pkg_arch):


### PR DESCRIPTION
Spacewalk server ignores the epoch and passes it within the version string, therefore:
Spacewalk was reporting Ubuntu servers with extra packages because of version mismatch and few errata reports were not showing up for the same reason

Modified to correspond to spacewalk backend parsing:
https://github.com/spacewalkproject/spacewalk/blob/master/backend/common/rhn_deb.py#L75-L84